### PR TITLE
Config service in production

### DIFF
--- a/{{cookiecutter.slug}}/frontend.angular/src/app/services/config.service.ts
+++ b/{{cookiecutter.slug}}/frontend.angular/src/app/services/config.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
+import { environment } from './../../environments/environment';
 
 export interface Config {
     backendUrl: string;
@@ -16,11 +17,18 @@ export class ConfigService {
     public get(): Promise<Config> {
         if (!this.config) {
             this.config = new Promise<Config>((resolve, reject) =>
-                this.http.get('/assets/config.json').subscribe(response => {
+                this.http.get(this.getConfigUrl()).subscribe(response => {
                     resolve(response as Config);
                 }));
         }
 
         return this.config;
+    }
+
+    public getConfigUrl(): string {
+        if (environment.production) {
+            return '/static/frontend_config.json';
+        }
+        return '/assets/config.json';
     }
 }


### PR DESCRIPTION
This is a tiny change that enhances cookiecutter application's `config-service.ts` to look for the config file in a different (standard) location in production mode.

@oktaal: could you please have a brief look if this is the way to check for production mode in Angular (it already works for the testapp, but still...)? Many thanks!