### PR TITLE
Remove /static prefix from Angular frontend assets (#16)

### DIFF
--- a/{{cookiecutter.slug}}/frontend.angular/src/app/footer/footer.component.html
+++ b/{{cookiecutter.slug}}/frontend.angular/src/app/footer/footer.component.html
@@ -12,11 +12,11 @@
                 </div>
                 <div class="column has-text-right-tablet">
                     <a class="university-logo image" href="https://uu.nl" target="_blank">
-                        <img src="/static/assets/utrecht-university.svg" alt="Utrecht University logo" width="200"
+                        <img src="/assets/utrecht-university.svg" alt="Utrecht University logo" width="200"
                             height="50" />
                     </a>
                     <a class="lab-logo image" href="https://dig.hum.uu.nl" target="_blank">
-                        <img src="/static/assets/dhlab.svg" alt="Digital Humanities Lab logo" width="200" height="40" />
+                        <img src="/assets/dhlab.svg" alt="Digital Humanities Lab logo" width="200" height="40" />
                     </a>
                 </div>
             </div>


### PR DESCRIPTION
@BeritJanssen This turned out to be actually quite simple. The frontend is not being served through the backend development server anymore, so assumptions about the backend magically inserting `/static` into frontend asset paths no longer hold. We can simply revert to "vanilla Angular" paths, in which case `ng serve` can find them without a problem.

The fanatical animated gif doesn't appear yet, because it is supposed to be retrieved from the backend and the backend is currently broken.