### PR TITLE
redockerize and deproxify

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -1,6 +1,7 @@
 {
   "project_title": "DigHum Pro",
   "slug": "{{cookiecutter.project_title | lower | replace('-', '') | replace(' ', '_')}}",
+  "npm_slug": "{{cookiecutter.slug | replace('_', '-')}}",
   "app_prefix": "dh",
   "description": "{{cookiecutter.project_title}} will humanize all your digits!",
   "author": "Research Software Lab, Centre for Digital Humanities, Utrecht University",

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -35,16 +35,16 @@ VIRTUALENV_COMMAND = '{{cookiecutter.virtualenv_command}}'.replace('%PYTHON%', p
 
 def main(argv):
     print('\nFiles generated. Performing final steps.')
-    # boot_sup = bootstrap_subprojects()
-    # if not boot_sup:
-    #     print(f'\nSubproject initialization failed. Please see {LOGFILE_NAME} for details.')
-    #     return 1
-    # try:
-    #     activate_frontend()
-    # except Exception as exception:
-    #     print(exception)
-    #     print("[ERROR] Activating frontend failed!!")
-    # if '{{cookiecutter.frontend}}' == 'backbone' and not generate_backbone_translations(): return 1
+    boot_sup = bootstrap_subprojects()
+    if not boot_sup:
+        print(f'\nSubproject initialization failed. Please see {LOGFILE_NAME} for details.')
+        return 1
+    try:
+        activate_frontend()
+    except Exception as exception:
+        print(exception)
+        print("[ERROR] Activating frontend failed!!")
+    if '{{cookiecutter.frontend}}' == 'backbone' and not generate_backbone_translations(): return 1
 
 
 def generate_backbone_translations():

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -41,65 +41,6 @@ def main(argv):
         print(exception)
         print("[ERROR] Activating frontend failed!!")
     if '{{cookiecutter.frontend}}' == 'backbone' and not generate_backbone_translations(): return 1
-    venv = create_virtualenv()
-    pip_tools = backreq = backpack = clone_req = funcreq = funcpack = False
-    if venv:
-        adopt_virtualenv(VIRTUALENV)
-        pip_tools = install_pip_tools()
-        if pip_tools:
-            check_version_pip()
-            check_version_pip_compile()
-            backreq = compile_backend_requirements()
-            if backreq:
-                backpack = install_backend_packages()
-                clone_req = copy_backreq_to_func()
-                if clone_req:
-                    funcreq = compile_functest_requirements()
-                    if funcreq:
-                        funcpack = install_functest_packages()
-    frontpack = install_frontend_packages()
-    git = setup_git()
-    gitflow = develop = stage = commit = remote = False
-    if git:
-        gitflow = setup_gitflow()
-        if not gitflow:
-            develop = create_develop_branch()
-        if funcreq and frontpack:
-            stage = git_add()
-            if stage:
-                commit = initial_commit()
-        remote = add_remote()
-    db = create_db()
-    if db:
-        db = grant_db()
-    migrate = superuser = False
-    if db and backpack:
-        migrate = run_migrations()
-        if migrate:
-            superuser = create_superuser()
-    if not all([superuser, remote, commit, gitflow, funcpack]):
-        print('\nPlease read {} for information on failed commands.'.format(LOGFILE_NAME))
-    print('\nAlmost ready to go! Just a couple more commands to run:')
-    print(cd_into_project)
-    if not venv: print(create_virtualenv)
-    print(activate_venv)
-    if not pip_tools: print(install_pip_tools)
-    if not backreq: print(compile_backend_requirements)
-    if not clone_req: print(copy_backreq_to_func)
-    if not funcreq: print(compile_functest_requirements)
-    if not (backpack and frontpack and funcpack): print(install_all_packages)
-    if not git: print(setup_git)
-    if not gitflow and not develop: print(create_develop_branch)
-    if not stage: print(git_add)
-    if not commit: print(initial_commit)
-    if not remote: print(add_remote)
-    if not db:
-        print(create_db)
-        print(grant_db)
-    if not migrate: print(run_migrations)
-    if not superuser: print(create_superuser)
-    print(git_push)
-    print(yarn_start)
 
 
 def generate_backbone_translations():

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -66,10 +66,7 @@ def generate_backbone_translations():
     return True
 
 
-bootstrap_subprojects = Command(
-    'Finalize subproject package configuration',
-    ['docker', 'compose', '-f', 'compose-postgenerate.yml', 'up']
-)
+bootstrap_subprojects = make_bootstrap_command('bootstrap')
 
 cd_into_project = Command('', ['cd', SLUG])
 

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -35,6 +35,10 @@ VIRTUALENV_COMMAND = '{{cookiecutter.virtualenv_command}}'.replace('%PYTHON%', p
 
 def main(argv):
     print('\nFiles generated. Performing final steps.')
+    boot_sup = bootstrap_subprojects()
+    if not boot_sup:
+        print(f'\nSubproject initialization failed. Please see {LOGFILE_NAME} for details.')
+        return 1
     try:
         activate_frontend()
     except Exception as exception:
@@ -61,6 +65,11 @@ def generate_backbone_translations():
     print('success.')
     return True
 
+
+bootstrap_subprojects = Command(
+    'Finalize subproject package configuration',
+    ['docker', 'compose', '-f', 'compose-postgenerate.yml', 'up']
+)
 
 cd_into_project = Command('', ['cd', SLUG])
 

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -66,7 +66,10 @@ def generate_backbone_translations():
     return True
 
 
-bootstrap_subprojects = make_bootstrap_command('bootstrap')
+bootstrap_subprojects = Command(
+    'Finalize subproject package configuration',
+    ['docker', 'compose', '-f', 'compose-postgenerate.yml', 'up']
+)
 
 cd_into_project = Command('', ['cd', SLUG])
 

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -35,16 +35,6 @@ VIRTUALENV_COMMAND = '{{cookiecutter.virtualenv_command}}'.replace('%PYTHON%', p
 
 def main(argv):
     print('\nFiles generated. Performing final steps.')
-    boot_sup = bootstrap_subprojects()
-    if not boot_sup:
-        print(f'\nSubproject initialization failed. Please see {LOGFILE_NAME} for details.')
-        return 1
-    try:
-        activate_frontend()
-    except Exception as exception:
-        print(exception)
-        print("[ERROR] Activating frontend failed!!")
-    if '{{cookiecutter.frontend}}' == 'backbone' and not generate_backbone_translations(): return 1
 
 
 def generate_backbone_translations():

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -35,16 +35,16 @@ VIRTUALENV_COMMAND = '{{cookiecutter.virtualenv_command}}'.replace('%PYTHON%', p
 
 def main(argv):
     print('\nFiles generated. Performing final steps.')
-    boot_sup = bootstrap_subprojects()
-    if not boot_sup:
-        print(f'\nSubproject initialization failed. Please see {LOGFILE_NAME} for details.')
-        return 1
-    try:
-        activate_frontend()
-    except Exception as exception:
-        print(exception)
-        print("[ERROR] Activating frontend failed!!")
-    if '{{cookiecutter.frontend}}' == 'backbone' and not generate_backbone_translations(): return 1
+    # boot_sup = bootstrap_subprojects()
+    # if not boot_sup:
+    #     print(f'\nSubproject initialization failed. Please see {LOGFILE_NAME} for details.')
+    #     return 1
+    # try:
+    #     activate_frontend()
+    # except Exception as exception:
+    #     print(exception)
+    #     print("[ERROR] Activating frontend failed!!")
+    # if '{{cookiecutter.frontend}}' == 'backbone' and not generate_backbone_translations(): return 1
 
 
 def generate_backbone_translations():

--- a/{{cookiecutter.slug}}/backend/Dockerfile-postgenerate
+++ b/{{cookiecutter.slug}}/backend/Dockerfile-postgenerate
@@ -1,0 +1,7 @@
+FROM python:3.9
+
+WORKDIR /usr/src/app/backend
+COPY requirements.in .
+RUN pip install -U pip pip-tools
+
+CMD pip-compile

--- a/{{cookiecutter.slug}}/bootstrap.py
+++ b/{{cookiecutter.slug}}/bootstrap.py
@@ -238,10 +238,10 @@ def activate_frontend():
     else:
         print('Unknown framework {{cookiecutter.frontend}} specified!')
     # remove other frameworks
-    for path in glob.glob("frontend.*"):
-        shutil.rmtree(path)
-    for path in glob.glob("package.*.json"):
-        os.remove(path)
+    # for path in glob.glob("frontend.*"):
+    #     shutil.rmtree(path)
+    # for path in glob.glob("package.*.json"):
+    #     os.remove(path)
 
 
 def override_json(filename):

--- a/{{cookiecutter.slug}}/bootstrap.py
+++ b/{{cookiecutter.slug}}/bootstrap.py
@@ -211,7 +211,6 @@ def activate_frontend():
         shutil.move(op.join('frontend', 'proxy.json'), 'proxy.json')
         override_json('package')
     elif framework == 'angular':
-        shutil.move(op.join('frontend', 'proxy.conf.json'), 'proxy.conf.json')
         override_json('package')
         if not angular_bootstrap_2():
             return false
@@ -235,6 +234,7 @@ def activate_frontend():
                     except FileNotFoundError:
                         pass
                     file.write(targeted)
+        shutil.move(op.join('frontend', 'proxy.conf.json'), 'proxy.conf.json')
     else:
         print('Unknown framework {{cookiecutter.frontend}} specified!')
     # remove other frameworks

--- a/{{cookiecutter.slug}}/bootstrap.py
+++ b/{{cookiecutter.slug}}/bootstrap.py
@@ -212,29 +212,29 @@ def activate_frontend():
         override_json('package')
     elif framework == 'angular':
         override_json('package')
-        # if not angular_bootstrap_2():
-        #     return false
-        # override_json('angular')
-        # if not angular_bootstrap_3():
-        #     return false
-        # for lang in '{{cookiecutter.localizations}}'.split(','):
-        #     [code, lang_name] = lang.split(':')
-        #     with open(f'frontend/locale/messages.xlf', 'r') as file:
-        #         messages = file.read()
-        #     if code != '{{cookiecutter.default_localization}}':
-        #         with open(f'frontend/locale/messages.{code}.xlf', 'w') as file:
-        #             # add the target-language attribute after the source-language attribute
-        #             targeted = re.sub(r'(source-language="[^"]+"[^>]*)', f'\\g<1> target-language="{code}"', messages)
-        #             try:
-        #                 with open(f'frontend/locale/messages.{code}.json', 'r') as pretranslated:
-        #                     translations = json.load(pretranslated)
-        #                     for key, value in translations.items():
-        #                         targeted = targeted.replace(f'<source>{key}</source>', f'<source>{key}</source>\n        <target state="translated">{value}</target>')
-        #                 os.remove(f'frontend/locale/messages.{code}.json')
-        #             except FileNotFoundError:
-        #                 pass
-        #             file.write(targeted)
-        # shutil.move(op.join('frontend', 'proxy.conf.json'), 'proxy.conf.json')
+        if not angular_bootstrap_2():
+            return false
+        override_json('angular')
+        if not angular_bootstrap_3():
+            return false
+        for lang in '{{cookiecutter.localizations}}'.split(','):
+            [code, lang_name] = lang.split(':')
+            with open(f'frontend/locale/messages.xlf', 'r') as file:
+                messages = file.read()
+            if code != '{{cookiecutter.default_localization}}':
+                with open(f'frontend/locale/messages.{code}.xlf', 'w') as file:
+                    # add the target-language attribute after the source-language attribute
+                    targeted = re.sub(r'(source-language="[^"]+"[^>]*)', f'\\g<1> target-language="{code}"', messages)
+                    try:
+                        with open(f'frontend/locale/messages.{code}.json', 'r') as pretranslated:
+                            translations = json.load(pretranslated)
+                            for key, value in translations.items():
+                                targeted = targeted.replace(f'<source>{key}</source>', f'<source>{key}</source>\n        <target state="translated">{value}</target>')
+                        os.remove(f'frontend/locale/messages.{code}.json')
+                    except FileNotFoundError:
+                        pass
+                    file.write(targeted)
+        shutil.move(op.join('frontend', 'proxy.conf.json'), 'proxy.conf.json')
     else:
         print('Unknown framework {{cookiecutter.frontend}} specified!')
     # remove other frameworks

--- a/{{cookiecutter.slug}}/bootstrap.py
+++ b/{{cookiecutter.slug}}/bootstrap.py
@@ -212,29 +212,29 @@ def activate_frontend():
         override_json('package')
     elif framework == 'angular':
         override_json('package')
-        if not angular_bootstrap_2():
-            return false
-        override_json('angular')
-        if not angular_bootstrap_3():
-            return false
-        for lang in '{{cookiecutter.localizations}}'.split(','):
-            [code, lang_name] = lang.split(':')
-            with open(f'frontend/locale/messages.xlf', 'r') as file:
-                messages = file.read()
-            if code != '{{cookiecutter.default_localization}}':
-                with open(f'frontend/locale/messages.{code}.xlf', 'w') as file:
-                    # add the target-language attribute after the source-language attribute
-                    targeted = re.sub(r'(source-language="[^"]+"[^>]*)', f'\\g<1> target-language="{code}"', messages)
-                    try:
-                        with open(f'frontend/locale/messages.{code}.json', 'r') as pretranslated:
-                            translations = json.load(pretranslated)
-                            for key, value in translations.items():
-                                targeted = targeted.replace(f'<source>{key}</source>', f'<source>{key}</source>\n        <target state="translated">{value}</target>')
-                        os.remove(f'frontend/locale/messages.{code}.json')
-                    except FileNotFoundError:
-                        pass
-                    file.write(targeted)
-        shutil.move(op.join('frontend', 'proxy.conf.json'), 'proxy.conf.json')
+        # if not angular_bootstrap_2():
+        #     return false
+        # override_json('angular')
+        # if not angular_bootstrap_3():
+        #     return false
+        # for lang in '{{cookiecutter.localizations}}'.split(','):
+        #     [code, lang_name] = lang.split(':')
+        #     with open(f'frontend/locale/messages.xlf', 'r') as file:
+        #         messages = file.read()
+        #     if code != '{{cookiecutter.default_localization}}':
+        #         with open(f'frontend/locale/messages.{code}.xlf', 'w') as file:
+        #             # add the target-language attribute after the source-language attribute
+        #             targeted = re.sub(r'(source-language="[^"]+"[^>]*)', f'\\g<1> target-language="{code}"', messages)
+        #             try:
+        #                 with open(f'frontend/locale/messages.{code}.json', 'r') as pretranslated:
+        #                     translations = json.load(pretranslated)
+        #                     for key, value in translations.items():
+        #                         targeted = targeted.replace(f'<source>{key}</source>', f'<source>{key}</source>\n        <target state="translated">{value}</target>')
+        #                 os.remove(f'frontend/locale/messages.{code}.json')
+        #             except FileNotFoundError:
+        #                 pass
+        #             file.write(targeted)
+        # shutil.move(op.join('frontend', 'proxy.conf.json'), 'proxy.conf.json')
     else:
         print('Unknown framework {{cookiecutter.frontend}} specified!')
     # remove other frameworks

--- a/{{cookiecutter.slug}}/bootstrap.py
+++ b/{{cookiecutter.slug}}/bootstrap.py
@@ -205,53 +205,15 @@ def merge_json(target, source):
 
 def activate_frontend():
     framework = '{{cookiecutter.frontend}}'
-    os.rename('package.{{cookiecutter.frontend}}.json', 'package.json')
 
     if framework == 'backbone':
         os.rename('frontend.backbone', 'frontend')
         shutil.move(op.join('frontend', 'proxy.json'), 'proxy.json')
         override_json('package')
     elif framework == 'angular':
-        project_name = '{{cookiecutter.slug}}'.replace('_', '-')
-        Command(
-            'Install dependencies',
-            ['yarn', 'install', '--ignore-scripts']
-        )()
-        Command(
-            'Creating project',
-            ['yarn', 'ng', 'new', project_name, '--prefix={{cookiecutter.app_prefix}}',
-                '--ssr',
-                '--skip-git=true',
-                '--skip-install=true',
-                '--package-manager=yarn',
-                '--style=scss',
-                '--routing=true']
-        )()
-        shutil.copytree('frontend.angular', project_name, dirs_exist_ok=True)
-        os.rename(project_name, 'frontend')
         shutil.move(op.join('frontend', 'proxy.conf.json'), 'proxy.conf.json')
         override_json('package')
-        Command(
-            'Install frontend dependencies using Yarn',
-            ['yarn'],
-            cwd="frontend"
-        )()
-        # Remove favicon.ico
-        os.remove(os.path.join('frontend', 'src', 'favicon.ico'))
-        # Remove editorconfig
-        os.remove(os.path.join('frontend', '.editorconfig'))
-        Command(
-            'ng add @angular/localize',
-            ['yarn', 'ng', 'add', '@angular/localize', '--skip-confirmation'],
-            cwd="frontend"
-        )()
-
         override_json('angular')
-        Command(
-            'Creating localizations',
-            ['yarn', 'i18n'],
-            cwd="frontend"
-        )()
         for lang in '{{cookiecutter.localizations}}'.split(','):
             [code, lang_name] = lang.split(':')
             with open(f'frontend/locale/messages.xlf', 'r') as file:
@@ -269,12 +231,6 @@ def activate_frontend():
                     except FileNotFoundError:
                         pass
                     file.write(targeted)
-        if '{{cookiecutter.frontend_port}}' != '4200':
-            Command(
-                'Set frontend port',
-                ['yarn', 'ng', 'config', "projects.{{cookiecutter.slug | replace('_', '-')}}.architect.serve.options.port", '{{cookiecutter.frontend_port}}'],
-                cwd="frontend"
-            )()
     else:
         print('Unknown framework {{cookiecutter.frontend}} specified!')
     # remove other frameworks

--- a/{{cookiecutter.slug}}/bootstrap.py
+++ b/{{cookiecutter.slug}}/bootstrap.py
@@ -259,7 +259,7 @@ def override_json(filename):
 
 def make_bootstrap_command(profile):
     return Command(
-        'Finalize subproject package configuration',
+        f'Finalize subproject package configuration ({profile})',
         ['docker', 'compose',
          '-f', 'compose-postgenerate.yml',
          '--profile', profile,

--- a/{{cookiecutter.slug}}/bootstrap.py
+++ b/{{cookiecutter.slug}}/bootstrap.py
@@ -213,7 +213,11 @@ def activate_frontend():
     elif framework == 'angular':
         shutil.move(op.join('frontend', 'proxy.conf.json'), 'proxy.conf.json')
         override_json('package')
+        if not angular_bootstrap_2():
+            return false
         override_json('angular')
+        if not angular_bootstrap_3():
+            return false
         for lang in '{{cookiecutter.localizations}}'.split(','):
             [code, lang_name] = lang.split(':')
             with open(f'frontend/locale/messages.xlf', 'r') as file:
@@ -252,6 +256,19 @@ def override_json(filename):
             json.dump(data, file, indent=4)
         os.remove(f'frontend/{filename}.overwrite.json')
 
+
+def make_bootstrap_command(profile):
+    return Command(
+        'Finalize subproject package configuration',
+        ['docker', 'compose',
+         '-f', 'compose-postgenerate.yml',
+         '--profile', profile,
+         'up']
+    )
+
+
+angular_bootstrap_2 = make_bootstrap_command('bootstrap-2')
+angular_bootstrap_3 = make_bootstrap_command('bootstrap-3')
 
 install_pip_tools = Command(
     'Install pip-tools',

--- a/{{cookiecutter.slug}}/bootstrap.py
+++ b/{{cookiecutter.slug}}/bootstrap.py
@@ -238,10 +238,10 @@ def activate_frontend():
     else:
         print('Unknown framework {{cookiecutter.frontend}} specified!')
     # remove other frameworks
-    # for path in glob.glob("frontend.*"):
-    #     shutil.rmtree(path)
-    # for path in glob.glob("package.*.json"):
-    #     os.remove(path)
+    for path in glob.glob("frontend.*"):
+        shutil.rmtree(path)
+    for path in glob.glob("package.*.json"):
+        os.remove(path)
 
 
 def override_json(filename):

--- a/{{cookiecutter.slug}}/bootstrap.py
+++ b/{{cookiecutter.slug}}/bootstrap.py
@@ -206,6 +206,8 @@ def activate_frontend():
         shutil.rmtree(path)
     for path in glob.glob("package.*.json"):
         os.remove(path)
+    os.remove(op.join('frontend', 'Dockerfile-postgenerate'))
+    shutil.rmtree(op.join('frontend', 'bootstrap'))
 
 
 install_pip_tools = Command(

--- a/{{cookiecutter.slug}}/compose-postgenerate.yml
+++ b/{{cookiecutter.slug}}/compose-postgenerate.yml
@@ -1,0 +1,17 @@
+services:
+    backend:
+        build:
+            context: ./backend
+            dockerfile: Dockerfile-postgenerate
+        volumes:
+            - ./backend:/usr/src/app/backend
+    frontend:
+        build:
+            context: ./frontend.{{cookiecutter.frontend}}
+            dockerfile: Dockerfile-postgenerate
+        volumes:
+            - ./frontend.{{cookiecutter.frontend}}:/usr/src/app/frontend
+            - frnomo:/usr/src/app/frontend/node_modules
+
+volumes:
+    frnomo:

--- a/{{cookiecutter.slug}}/compose-postgenerate.yml
+++ b/{{cookiecutter.slug}}/compose-postgenerate.yml
@@ -1,17 +1,37 @@
 services:
     backend:
+        profiles: ['bootstrap']
         build:
             context: ./backend
             dockerfile: Dockerfile-postgenerate
         volumes:
             - ./backend:/usr/src/app/backend
     frontend:
+        profiles: ['bootstrap']
         build:
             context: ./frontend.{{cookiecutter.frontend}}
             dockerfile: Dockerfile-postgenerate
-        volumes:
+            {% if cookiecutter.frontend == 'angular' %}
+            target: bootstrap
+            {% endif %}
+        volumes: &frontend-volumes
             - ./frontend:/usr/src/app/frontend
             - frnomo:/usr/src/app/frontend/node_modules
+    {% if cookiecutter.frontend == 'angular' %}
+    frontend-2:
+        profiles: ['bootstrap-2']
+        build: &angular-staged-build
+            context: ./frontend
+            dockerfile: ../frontend.angular/Dockerfile-postgenerate
+            target: bootstrap-2
+        volumes: *frontend-volumes
+    frontend-3:
+        profiles: ['bootstrap-3']
+        build:
+            <<: *angular-staged-build
+            target: bootstrap-3
+        volumes: *frontend-volumes
+    {% endif %}
 
 volumes:
     frnomo:

--- a/{{cookiecutter.slug}}/compose-postgenerate.yml
+++ b/{{cookiecutter.slug}}/compose-postgenerate.yml
@@ -1,37 +1,17 @@
 services:
     backend:
-        profiles: ['bootstrap']
         build:
             context: ./backend
             dockerfile: Dockerfile-postgenerate
         volumes:
             - ./backend:/usr/src/app/backend
     frontend:
-        profiles: ['bootstrap']
         build:
             context: ./frontend.{{cookiecutter.frontend}}
             dockerfile: Dockerfile-postgenerate
-            {% if cookiecutter.frontend == 'angular' %}
-            target: bootstrap
-            {% endif %}
-        volumes: &frontend-volumes
+        volumes:
             - ./frontend:/usr/src/app/frontend
             - frnomo:/usr/src/app/frontend/node_modules
-    {% if cookiecutter.frontend == 'angular' %}
-    frontend-2:
-        profiles: ['bootstrap-2']
-        build: &angular-staged-build
-            context: ./frontend
-            dockerfile: ../frontend.angular/Dockerfile-postgenerate
-            target: bootstrap-2
-        volumes: *frontend-volumes
-    frontend-3:
-        profiles: ['bootstrap-3']
-        build:
-            <<: *angular-staged-build
-            target: bootstrap-3
-        volumes: *frontend-volumes
-    {% endif %}
 
 volumes:
     frnomo:

--- a/{{cookiecutter.slug}}/compose-postgenerate.yml
+++ b/{{cookiecutter.slug}}/compose-postgenerate.yml
@@ -10,7 +10,7 @@ services:
             context: ./frontend.{{cookiecutter.frontend}}
             dockerfile: Dockerfile-postgenerate
         volumes:
-            - ./frontend.{{cookiecutter.frontend}}:/usr/src/app/frontend
+            - ./frontend:/usr/src/app/frontend
             - frnomo:/usr/src/app/frontend/node_modules
 
 volumes:

--- a/{{cookiecutter.slug}}/frontend.angular/Dockerfile-postgenerate
+++ b/{{cookiecutter.slug}}/frontend.angular/Dockerfile-postgenerate
@@ -1,4 +1,4 @@
-FROM node:18 as bootstrap
+FROM node:18 AS bootstrap-1
 
 WORKDIR /usr/src/app
 RUN yarn init -yp && \
@@ -15,25 +15,33 @@ RUN yarn init -yp && \
 WORKDIR /usr/src/app/{{cookiecutter.npm_slug}}
 COPY . .
 
-VOLUME /usr/src/app/frontend
-CMD cp package.json package.overwrite.json ../frontend/
+FROM python:3.9 AS bootstrap-2
 
-FROM bootstrap as bootstrap-2
+WORKDIR /usr/src/app
+COPY --from=bootstrap-1 \
+     /usr/src/app/{{cookiecutter.npm_slug}} frontend/
 
-WORKDIR /usr/src/app/{{cookiecutter.npm_slug}}
-COPY package.json ./
+WORKDIR /usr/src/app/frontend
+RUN python bootstrap/override_json.py package
+
+FROM node:18 AS bootstrap-3
+
+WORKDIR /usr/src/app/frontend
 RUN rm src/favicon.ico .editorconfig && \
     yarn && \
     yarn ng add @angular/localize --skip-confirmation
 
-VOLUME /usr/src/app/frontend
-CMD cp angular.json angular.overwrite.json ../frontend/
+FROM python:3.9 AS bootstrap-4
 
-FROM bootstrap-2 as bootstrap-3
+WORDIR /usr/src/app/frontend
+RUN python bootstrap/override_json.py angular
 
-WORKDIR /usr/src/app/{{cookiecutter.npm_slug}}
-COPY angular.json ./
+FROM node:18 AS bootstrap-5
+
+WORKDIR /usr/src/app/frontend
 RUN yarn ng extract-i18n --output-path locale
 
-VOLUME /usr/src/app/frontend
-CMD cp -r * .* ../frontend/
+FROM python:3.9 AS bootstrap-6
+
+WORKDIR /usr/src/app/frontend
+RUN python bootstrap/finish_localizations.py

--- a/{{cookiecutter.slug}}/frontend.angular/Dockerfile-postgenerate
+++ b/{{cookiecutter.slug}}/frontend.angular/Dockerfile-postgenerate
@@ -27,7 +27,7 @@ RUN rm src/favicon.ico .editorconfig && \
     yarn ng add @angular/localize --skip-confirmation
 
 VOLUME /usr/src/app/frontend
-CMD cp angular{,.overwrite}.json ../frontend/
+CMD cp angular.json angular.overwrite.json ../frontend/
 
 FROM bootstrap-2 as bootstrap-3
 

--- a/{{cookiecutter.slug}}/frontend.angular/Dockerfile-postgenerate
+++ b/{{cookiecutter.slug}}/frontend.angular/Dockerfile-postgenerate
@@ -12,10 +12,11 @@ RUN yarn init -yp && \
         --style=scss \
         --routing=true
 
-COPY . /usr/src/app/{{cookiecutter.npm_slug}}
+WORKDIR /usr/src/app/{{cookiecutter.npm_slug}}
+COPY . .
 
 VOLUME /usr/src/app/frontend
-CMD cp {{cookiecutter.npm_slug}}/package{,.overwrite}.json frontend/
+CMD cp package.json package.overwrite.json ../frontend/
 
 FROM bootstrap as bootstrap-2
 

--- a/{{cookiecutter.slug}}/frontend.angular/Dockerfile-postgenerate
+++ b/{{cookiecutter.slug}}/frontend.angular/Dockerfile-postgenerate
@@ -12,7 +12,7 @@ RUN yarn init -yp && \
         --style=scss \
         --routing=true
 
-COPY . /usr/src/app/{{cookiecutter.npm_slug}}/
+COPY . /usr/src/app/{{cookiecutter.npm_slug}}
 
 VOLUME /usr/src/app/frontend
 CMD cp {{cookiecutter.npm_slug}}/package{,.overwrite}.json frontend/
@@ -26,7 +26,7 @@ RUN rm src/favicon.ico .editorconfig && \
     yarn ng add @angular/localize --skip-confirmation
 
 VOLUME /usr/src/app/frontend
-CMD cp angular{,.overwrite}.json ../frontend
+CMD cp angular{,.overwrite}.json ../frontend/
 
 FROM bootstrap-2 as bootstrap-3
 

--- a/{{cookiecutter.slug}}/frontend.angular/Dockerfile-postgenerate
+++ b/{{cookiecutter.slug}}/frontend.angular/Dockerfile-postgenerate
@@ -10,14 +10,14 @@ RUN yarn init -yp && \
         --skip-install=true \
         --package-manager=yarn \
         --style=scss \
-        --routing=true && \
-    mv {{cookiecutter.npm_slug}} frontend
+        --routing=true
 
-COPY . /usr/src/app/frontend/
-WORKDIR /usr/src/app/frontend
+COPY . /usr/src/app/{{cookiecutter.npm_slug}}/
+WORKDIR /usr/src/app/{{cookiecutter.npm_slug}}
 RUN rm src/favicon.ico .editorconfig && \
+    yarn && \
     yarn ng add @angular/localize --skip-confirmation && \
-    yarn i18n
+    yarn ng extract-i18n --output-path locale
 
 VOLUME /usr/src/app/frontend
-CMD echo done
+CMD cp -r * .* ../frontend/

--- a/{{cookiecutter.slug}}/frontend.angular/Dockerfile-postgenerate
+++ b/{{cookiecutter.slug}}/frontend.angular/Dockerfile-postgenerate
@@ -1,0 +1,23 @@
+FROM node:18 as bootstrap
+
+WORKDIR /usr/src/app
+RUN yarn init -yp && \
+    yarn add "@angular/cli@17" && \
+    yarn ng new {{cookiecutter.npm_slug}} \
+        --prefix={{cookiecutter.app_prefix}} \
+        --ssr \
+        --skip-git=true \
+        --skip-install=true \
+        --package-manager=yarn \
+        --style=scss \
+        --routing=true && \
+    mv {{cookiecutter.npm_slug}} frontend
+
+COPY . /usr/src/app/frontend/
+WORKDIR /usr/src/app/frontend
+RUN rm src/favicon.ico .editorconfig && \
+    yarn ng add @angular/localize --skip-confirmation && \
+    yarn i18n
+
+VOLUME /usr/src/app/frontend
+CMD echo done

--- a/{{cookiecutter.slug}}/frontend.angular/Dockerfile-postgenerate
+++ b/{{cookiecutter.slug}}/frontend.angular/Dockerfile-postgenerate
@@ -33,7 +33,7 @@ RUN rm src/favicon.ico .editorconfig && \
 
 FROM python:3.9 AS bootstrap-4
 
-WORDIR /usr/src/app/frontend
+WORKDIR /usr/src/app/frontend
 RUN python bootstrap/override_json.py angular
 
 FROM node:18 AS bootstrap-5

--- a/{{cookiecutter.slug}}/frontend.angular/Dockerfile-postgenerate
+++ b/{{cookiecutter.slug}}/frontend.angular/Dockerfile-postgenerate
@@ -13,11 +13,26 @@ RUN yarn init -yp && \
         --routing=true
 
 COPY . /usr/src/app/{{cookiecutter.npm_slug}}/
+
+VOLUME /usr/src/app/frontend
+CMD cp {{cookiecutter.npm_slug}}/package{,.overwrite}.json frontend/
+
+FROM bootstrap as bootstrap-2
+
 WORKDIR /usr/src/app/{{cookiecutter.npm_slug}}
+COPY package.json ./
 RUN rm src/favicon.ico .editorconfig && \
     yarn && \
-    yarn ng add @angular/localize --skip-confirmation && \
-    yarn ng extract-i18n --output-path locale
+    yarn ng add @angular/localize --skip-confirmation
+
+VOLUME /usr/src/app/frontend
+CMD cp angular{,.overwrite}.json ../frontend
+
+FROM bootstrap-2 as bootstrap-3
+
+WORKDIR /usr/src/app/{{cookiecutter.npm_slug}}
+COPY angular.json ./
+RUN yarn ng extract-i18n --output-path locale
 
 VOLUME /usr/src/app/frontend
 CMD cp -r * .* ../frontend/

--- a/{{cookiecutter.slug}}/frontend.angular/Dockerfile-postgenerate
+++ b/{{cookiecutter.slug}}/frontend.angular/Dockerfile-postgenerate
@@ -27,6 +27,7 @@ RUN python bootstrap/override_json.py package
 FROM node:18 AS bootstrap-3
 
 WORKDIR /usr/src/app/frontend
+COPY --from=bootstrap-2 /usr/src/app/frontend/ .
 RUN rm src/favicon.ico .editorconfig && \
     yarn && \
     yarn ng add @angular/localize --skip-confirmation
@@ -34,14 +35,17 @@ RUN rm src/favicon.ico .editorconfig && \
 FROM python:3.9 AS bootstrap-4
 
 WORKDIR /usr/src/app/frontend
+COPY --from=bootstrap-3 /usr/src/app/frontend/ .
 RUN python bootstrap/override_json.py angular
 
 FROM node:18 AS bootstrap-5
 
 WORKDIR /usr/src/app/frontend
+COPY --from=bootstrap-4 /usr/src/app/frontend/ .
 RUN yarn ng extract-i18n --output-path locale
 
 FROM python:3.9 AS bootstrap-6
 
 WORKDIR /usr/src/app/frontend
+COPY --from=bootstrap-5 /usr/src/app/frontend/ .
 RUN python bootstrap/finish_localizations.py

--- a/{{cookiecutter.slug}}/frontend.angular/bootstrap/finish_localizations.py
+++ b/{{cookiecutter.slug}}/frontend.angular/bootstrap/finish_localizations.py
@@ -1,0 +1,27 @@
+import re
+import json
+import os
+
+
+def main():
+    for lang in '{{cookiecutter.localizations}}'.split(','):
+        [code, lang_name] = lang.split(':')
+        with open(f'locale/messages.xlf', 'r') as file:
+            messages = file.read()
+        if code != '{{cookiecutter.default_localization}}':
+            with open(f'locale/messages.{code}.xlf', 'w') as file:
+                # add the target-language attribute after the source-language attribute
+                targeted = re.sub(r'(source-language="[^"]+"[^>]*)', f'\\g<1> target-language="{code}"', messages)
+                try:
+                    with open(f'locale/messages.{code}.json', 'r') as pretranslated:
+                        translations = json.load(pretranslated)
+                        for key, value in translations.items():
+                            targeted = targeted.replace(f'<source>{key}</source>', f'<source>{key}</source>\n        <target state="translated">{value}</target>')
+                            os.remove(f'locale/messages.{code}.json')
+                except FileNotFoundError:
+                    pass
+                file.write(targeted)
+
+
+if __name__ == '__main__':
+    main()

--- a/{{cookiecutter.slug}}/frontend.angular/bootstrap/override_json.py
+++ b/{{cookiecutter.slug}}/frontend.angular/bootstrap/override_json.py
@@ -1,0 +1,31 @@
+import os
+import sys
+
+
+def merge_json(target, source):
+    for key, value in source.items():
+        if value is None:
+            del target[key]
+        elif key in target and isinstance(target[key], dict) and \
+                isinstance(source[key], dict):
+            merge_json(target[key], source[key])
+        else:
+            target[key] = value
+    return target
+
+
+def override_json(filename):
+    if os.path.isfile(f'{filename}.overwrite.json'):
+        print(f'Overriding {filename}.json')
+        with open(f'{filename}.overwrite.json', 'r') as file:
+            overwrite = json.load(file)
+        with open(f'{filename}.json', 'r') as file:
+            data = json.load(file)
+        with open(f'{filename}.json', 'w') as file:
+            merge_json(data, overwrite)
+            json.dump(data, file, indent=4)
+        os.remove(f'{filename}.overwrite.json')
+
+
+if __name__ == '__main__':
+    override_json(sys.argv[1])

--- a/{{cookiecutter.slug}}/frontend.angular/bootstrap/override_json.py
+++ b/{{cookiecutter.slug}}/frontend.angular/bootstrap/override_json.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import json
 
 
 def merge_json(target, source):


### PR DESCRIPTION
This is a work in progress. This description will likely be updated at least a few times in the future. I will certainly rebase and force-push the branch multiple times.

I am trying to close #16 and close #35 at the same time. My intention is to first get everything working in Docker and then git rid of the proxy situation. I'm currently having some trouble with Docker and am hoping that @BeritJanssen can take a look. See my own review below for details.

| Pre-existing situation | Intended result |
|---|---|
| Generator needs to have Python 3.10 (?), `cookiecutter`, node.js 18 and `@angular/cli` installed | Generator needs to have some version of Python 3, `cookiecutter` and Docker installed |
| Developer needs to have Python 3.10, node.js 18, PostgreSQL>10 and all other dependencies installed | Developer only needs Docker on the host machine |
| Frontend and backend proxy to each other via complex injected configuration | HTTP server (probably nginx) reverse proxies to both, no configuration injection needed |

I envision the global workflow as follows:

1. `cookiecutter` generates initial files based on template directory. This part doesn't change much.
2. Generation of additional files such as in `ng new` is taken care of in the post-generation hook using `docker-compose`. To this end, the frontend and backend both have a special `Dockerfile-postgenerate` and the project root has a special `compose-postgenerate.yml`, which get deleted right after generation is done. This is the part where I'm currently having trouble.
3. End result of the cookiecutter is a directory that is ready to be committed to git and shared with other developers. This part doesn't fundamentally change.
4. The code tree is ready to run with `docker-compose up`. It is no longer necessary to run `python bootstrap.py` on the first run after cloning. Some of the logic in the `bootstrap.py` is still needed during generation, but it can be merged into the `hooks/post_gen_project.py`.