### PR TITLE
Run subprocesses through shell on Windows

### DIFF
--- a/{{cookiecutter.slug}}/bootstrap.py
+++ b/{{cookiecutter.slug}}/bootstrap.py
@@ -46,7 +46,11 @@ class Command(object):
         print('{}... '.format(self.description), end='', flush=True)
         log.write('$ {}\n\n'.format(self))
         try:
-            exit_code = subprocess.call(self.command, *self.args, **self.kwargs)
+            # On Windows, we need to run the command through the shell to get
+            # access to commands in PATH.
+            exit_code = subprocess.call(
+                self.command, *self.args, **self.kwargs, shell=WINDOWS
+            )
             if exit_code != 0:
                 print('failed ({}).'.format(exit_code))
                 return False
@@ -76,7 +80,7 @@ def main(argv):
     frontpack = install_frontend_packages()
     db, create_db = prepare_db()
     migrate = superuser = False
-    db, grant_db = access_db(db)
+    # db, grant_db = access_db(db)
     if db and backpack:
         migrate = run_migrations()
         if migrate:
@@ -94,7 +98,7 @@ def main(argv):
     if not (pip_tools and backpack and frontpack and funcpack): print(install_all_packages)
     if not db:
         print(create_db)
-        print(grant_db)
+        # print(grant_db)
     if not migrate: print(run_migrations)
     if not superuser: print(create_superuser)
     if not main_branch: print(track_main)

--- a/{{cookiecutter.slug}}/bootstrap.py
+++ b/{{cookiecutter.slug}}/bootstrap.py
@@ -80,7 +80,7 @@ def main(argv):
     frontpack = install_frontend_packages()
     db, create_db = prepare_db()
     migrate = superuser = False
-    # db, grant_db = access_db(db)
+    db, grant_db = access_db(db)
     if db and backpack:
         migrate = run_migrations()
         if migrate:
@@ -98,7 +98,7 @@ def main(argv):
     if not (pip_tools and backpack and frontpack and funcpack): print(install_all_packages)
     if not db:
         print(create_db)
-        # print(grant_db)
+        print(grant_db)
     if not migrate: print(run_migrations)
     if not superuser: print(create_superuser)
     if not main_branch: print(track_main)


### PR DESCRIPTION
Partly solves #48 

Without `shell=True`, almost every call of `subprocess.call()` fails on Windows; if I add it, (almost) everything works right out of the box.

This will probably be hard to test for non-Windows users. I'm mainly concerned about the potential security risk mentioned on [StackExchange](https://stackoverflow.com/questions/3022013/windows-cant-find-the-file-on-subprocess-call). 

Since we're using cookiecutter to set up a local project and all input is controlled, the risk of allowing arbitrary code execution seems very small.