### PR TITLE
Upgrade Ubuntu 20 > 22

### DIFF
--- a/{{cookiecutter.slug}}/.github/workflows/test.yml
+++ b/{{cookiecutter.slug}}/.github/workflows/test.yml
@@ -17,7 +17,7 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     services:
       # Label used to access the service container


### PR DESCRIPTION
https://github.blog/changelog/2025-01-15-github-actions-ubuntu-20-runner-image-brownout-dates-and-other-breaking-changes/