### PR TITLE
Update Python/Node

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     services:
       # Label used to access the service container
@@ -38,8 +38,8 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ['3.8', '3.9']
-        node-version: ['18.x', '20.x']
+        python-version: ['3.11']
+        node-version: ['22.x']
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}

--- a/{{cookiecutter.slug}}/.github/workflows/test.yml
+++ b/{{cookiecutter.slug}}/.github/workflows/test.yml
@@ -41,8 +41,8 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ['3.8']
-        node-version: ['18.x', '20.x']
+        python-version: ['3.9', '3.11']
+        node-version: ['20.x', '22.x']
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python {{ "${{ matrix.python-version }}" }}

--- a/{{cookiecutter.slug}}/.github/workflows/test.yml
+++ b/{{cookiecutter.slug}}/.github/workflows/test.yml
@@ -41,8 +41,8 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ['3.9', '3.11']
-        node-version: ['20.x', '22.x']
+        python-version: ['3.11']
+        node-version: ['22.x']
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python {{ "${{ matrix.python-version }}" }}


### PR DESCRIPTION
Bumps the Python and Node versions of the test runner to Python 3.11 and Node 22.

According to the System Team, Python 3.9 is currently the version used for standard new servers, but use of 3.11 is preferred.