### PR TITLE
Prevent slugs containing dashes

### DIFF
--- a/hooks/pre_gen_project.py
+++ b/hooks/pre_gen_project.py
@@ -1,0 +1,4 @@
+# slug cannot contain dash, spaces or dots
+# as these are not allowed in python module names
+{{ cookiecutter.update({"slug": cookiecutter.slug.replace('.', '_').replace(' ', '_').replace('-', '_')}) }}
+


### PR DESCRIPTION
It's fine if those end up in the origin URL though. E.g. `fg-ai` should still be named `fg-ai` on github (and in Angular it's also fine I guess). But having `fg-ai` as a module in name in Python? Oof.