### PR TITLE
Overwrite email_confirmation_message.txt template

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -25,6 +25,7 @@
     "frontend.backbone/src/global/hbsHelpers.ts",
     "frontend.angular/src/app/user/*.html",
     "frontend.angular/src/app/toast-container/*.html",
-    "frontend.angular/src/app/menu/user-menu/*.html"
+    "frontend.angular/src/app/menu/user-menu/*.html",
+    "backend/user/templates/accounts/email/email_confirmation_message.txt"
   ]
 }

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -26,6 +26,6 @@
     "frontend.angular/src/app/user/*.html",
     "frontend.angular/src/app/toast-container/*.html",
     "frontend.angular/src/app/menu/user-menu/*.html",
-    "backend/user/templates/accounts/email/email_confirmation_message.txt"
+    "backend/user/templates/account/email/email_confirmation_message.txt"
   ]
 }

--- a/{{cookiecutter.slug}}/backend/user/templates/account/email/email_confirmation_message.txt
+++ b/{{cookiecutter.slug}}/backend/user/templates/account/email/email_confirmation_message.txt
@@ -1,0 +1,15 @@
+{% extends "account/email/base_message.txt" %}
+{% load account %}
+{% load i18n %}
+
+{% comment %}
+This overrides the original found at allauth/templates/account/email/email_confirmation_message.txt.
+
+The original wording may be taken to suggest that someone else (not the user)
+created an account for the person receiving the email. The updated wording here
+clarifies that the user themselves created the account and avoids potential
+impersonation concerns.
+{% endcomment %}
+{% block content %}{% autoescape off %}{% user_display user as user_display %}{% blocktrans with site_name=current_site.name site_domain=current_site.domain %}You're receiving this email because someone used your email address to register an account with the name "{{ user_display}}" on {{ site_domain }}.
+
+If this was you and you wish to confirm your email address, go to {{ activate_url }}{% endblocktrans %}{% endautoescape %}{% endblock content %}

--- a/{{cookiecutter.slug}}/backend/user/templates/account/email/email_confirmation_message.txt
+++ b/{{cookiecutter.slug}}/backend/user/templates/account/email/email_confirmation_message.txt
@@ -10,6 +10,6 @@ created an account for the person receiving the email. The updated wording here
 clarifies that the user themselves created the account and avoids potential
 impersonation concerns.
 {% endcomment %}
-{% block content %}{% autoescape off %}{% user_display user as user_display %}{% blocktrans with site_name=current_site.name site_domain=current_site.domain %}You're receiving this email because someone used your email address to register an account with the name "{{ user_display}}" on {{ site_domain }}.
+{% block content %}{% autoescape off %}{% user_display user as user_display_name %}{% blocktrans with site_name=current_site.name site_domain=current_site.domain %}You're receiving this email because someone used your email address to register an account with the name "{{ user_display_name }}" on {{ site_domain }}.
 
 If this was you and you wish to confirm your email address, go to {{ activate_url }}{% endblocktrans %}{% endautoescape %}{% endblock content %}

--- a/{{cookiecutter.slug}}/backend/{{cookiecutter.slug}}/settings.py
+++ b/{{cookiecutter.slug}}/backend/{{cookiecutter.slug}}/settings.py
@@ -34,7 +34,9 @@ ROOT_URLCONF = '{{cookiecutter.slug}}.urls'
 TEMPLATES = [
     {
         'BACKEND': 'django.template.backends.django.DjangoTemplates',
-        'DIRS': [],
+        'DIRS': [
+            os.path.join(BASE_DIR, 'user', 'templates'),
+        ],
         'APP_DIRS': True,
         'OPTIONS': {
             'context_processors': [


### PR DESCRIPTION
For Lettercraft, a (very minor) vulnerability was reported in a responsible disclosure call. The corresponding issue and more context can be found [here](https://github.com/CentreForDigitalHumanities/lettercraft/issues/252).

In principle, this is a 'risk' for all future applications that are based on our CookieCutter and make use of the authentication module.